### PR TITLE
Hyperconductive stage quest name incorrect

### DIFF
--- a/03-HW/04-Hyperconductive/HyperconduvtiveViewModel.cs
+++ b/03-HW/04-Hyperconductive/HyperconduvtiveViewModel.cs
@@ -106,7 +106,7 @@ namespace FFXIVRelicTracker._03_HW._04_Hyperconductive
         }
         public int NeededOil { get { if (AvailableJobs == null) { LoadAvailableJobs(); }  return Math.Max(0,AvailableJobs.Count * 5 - OilCount); } }
         public int Poetics { get { return NeededOil * 350; } }
-        public string QuestName { get { if (AvailableJobs != null) { if (AvailableJobs.Count == 13) { return "Finding Your Voice"; } else { return "Soul Without Life"; } } else { return "Finding Your Voice"; } } }
+        public string QuestName { get { if (AvailableJobs != null) { if (AvailableJobs.Count != 13) { return "Finding Your Voice"; } else { return "Soul Without Life"; } } else { return "Finding Your Voice"; } } }
         #endregion
 
         #region Methods


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/56663405/98758864-d91ddb80-2423-11eb-9255-db7fd090abd9.png)

Fixes issue with incorrect name for Hyperconductive (HW) quest appearing when the quest is repeated with a new weapon.

For context, I was doing this on NIN, and had done all others but SCH, AST, and MCH, therefore it should have said `Finding Your Voice`.